### PR TITLE
GS-1011: Template Update Doesn't Update Dataset Variables

### DIFF
--- a/classes/presets_control.php
+++ b/classes/presets_control.php
@@ -217,7 +217,7 @@ class presets_control extends \admin_setting {
         $fields['script'] = 'templatescript';
         $fields['style'] = 'templatestyle';
         $fields['dataset'] = 'dataset';
-        $fields['datavars'] = 'datavars';
+        $fields['datasetvars'] = 'datasetvars';
 
         foreach ($fields as $fieldkey => $fieldname) {
             if (array_key_exists($fieldkey, $preset)) {


### PR DESCRIPTION
## Description:
<!-- Describe your changes in detail / numbered list of distinct changes for reference -->
Correct dataset variables config and bundle key used for updating templates.
I've confirmed that this naming matches both the JS bundler logic which writes to `controls.datasetvars` and both it looks for and the actual page element is 'datasetvars_x'.
Searching for 'datavars' in the plugin code before this change only returns the two occurrences which are being changed in this PR.

## Checklist before requesting a review:
<!-- Remove non-applicable items e.g. epic sub-issue points -->
<!-- Add an 'x' inside the brackets to check the item -->

- [x] I have performed a self review of my code.
- [x] My code follows the [Moodle Coding Style](https://moodledev.io/general/development/policies/codingstyle).
- ~~Version numbers have been updated.~~
- [x] Code has been commented, particularly in hard-to-understand areas.
