### PR TITLE
GS-1118 Moodle 4.5 Generico Issues

### DIFF
--- a/classes/text_filter.php
+++ b/classes/text_filter.php
@@ -16,6 +16,8 @@
 
 namespace filter_generico;
 
+use Exception;
+
 if (class_exists('\core_filters\text_filter')) {
     class_alias('\core_filters\text_filter', 'generico_base_text_filter');
 } else {

--- a/classes/text_filter.php
+++ b/classes/text_filter.php
@@ -464,7 +464,7 @@ class text_filter extends \generico_base_text_filter {
         $filterprops['DATASET'] = false;
         if ($datasetbody) {
             $vars = [];
-            if ($datasetvars) {
+            if ($datasetvars !== '') {
                 $vars = explode(',', $datasetvars);
             }
             // Turn numeric vars into numbers (not strings).

--- a/classes/text_filter.php
+++ b/classes/text_filter.php
@@ -485,6 +485,8 @@ class text_filter extends \generico_base_text_filter {
                     if (count($filterprops['DATASET']) == 1) {
                         $thedata = get_object_vars(reset($alldata));
                         foreach ($thedata as $name => $value) {
+                            $value ??= '';
+
                             $genericotemplate = str_replace('@@DATASET:' . $name . '@@', $value, $genericotemplate);
                             $alternatecontent = str_replace('@@DATASET:' . $name . '@@', $value, $alternatecontent);
                         }


### PR DESCRIPTION
## Description:
<!-- Describe your changes in detail / numbered list of distinct changes for reference -->

1. Add missing `Exception` import that caused `catch` clause to not work and allowed dataset exceptions to kill the page.
2. Default `null` dataset values to empty string to prevent PHP deprecation notice for passing `null` to `str_replace()`.
3. Explicitly check that the parsed `$datasetvars` is an empty string to prevent cases where it is literal or string zero resulting in a query param count mismatch due to them not being populated.
This was notably breaking the site home page when viewed while not logged in due to _LOLCustomSearch_ having `@@USER:id@@` as its dataset variables which once parsed resulted in `"0"`.

## Checklist before requesting a review:
<!-- Remove non-applicable items e.g. epic sub-issue points -->
<!-- Add an 'x' inside the brackets to check the item -->

- [x] I have performed a self review of my code.
- [x] My code follows the [Moodle Coding Style](https://moodledev.io/general/development/policies/codingstyle).
- ~~Version numbers have been updated.~~
- [x] Code has been commented, particularly in hard-to-understand areas.
